### PR TITLE
REFACTOR unix commands to use common pwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ LAREX expects the corresponding .jar to be located in /src/main/WEB-INF/lib and 
 `ln -s /usr/share/java/opencv.jar LAREX/Larex/src/main/webapp/WEB-INF/lib/opencv.jar`
 
 #### Compile
-run `mvn clean install` in the root dir. This dir contains the `pom.xml`.
+run `mvn clean install -f LAREX/Larex/pom.xml`.
 
 #### Copy or link the created war file to tomcat
 Either:
-`sudo ln -s $PWD/target/Larex.war /var/lib/tomcat7/webapps/Larex.war`
+`sudo ln -s LAREX/Larex/target/Larex.war /var/lib/tomcat7/webapps/Larex.war`
 
 or
 
-`cp target/Larex.war /var/lib/tomcat7/webapps/Larex.war`
+`cp LAREX/Larex/target/Larex.war /var/lib/tomcat7/webapps/Larex.war`
 
 #### If you had to compile OpenCV on your own
 set `LD_LIBRARY_PATH` to `$CMAKE_INSTALL_PREFIX/share/OpenCV/java` when starting the Tomcat server.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ LAREX expects the corresponding .jar to be located in /src/main/WEB-INF/lib and 
 `apt-get install openjdk-8-jdk`
 
 #### Link the opencv.jar
-cd *your git rep*/Larex/src/main/webapp/WEB-INF
+`cd LAREX/Larex/src/main/webapp/WEB-INF`
 
-mkdir lib && cd lib
+`mkdir lib && cd lib`
 
-ln -s /usr/share/java/opencv.jar
+`ln -s /usr/share/java/opencv.jar`
 
 #### Compile
 run `mvn clean install` in the root dir. This dir contains the `pom.xml`.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ LAREX expects the corresponding .jar to be located in /src/main/WEB-INF/lib and 
 
 `apt-get install openjdk-8-jdk`
 
+#### Clone Repository
+`git clone https://github.com/chreul/LAREX.git`
+
 #### Link the opencv.jar
 `cd LAREX/Larex/src/main/webapp/WEB-INF`
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ LAREX expects the corresponding .jar to be located in /src/main/WEB-INF/lib and 
 `apt-get install openjdk-8-jdk`
 
 #### Link the opencv.jar
-cd *your git rep*/Larex/src/main/WEB-INF
+cd *your git rep*/Larex/src/main/webapp/WEB-INF
 
 mkdir lib && cd lib
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ LAREX expects the corresponding .jar to be located in /src/main/WEB-INF/lib and 
 `git clone https://github.com/chreul/LAREX.git`
 
 #### Link the opencv.jar
-`cd LAREX/Larex/src/main/webapp/WEB-INF`
+`mkdir LAREX/Larex/src/main/webapp/WEB-INF/lib`
 
-`mkdir lib && cd lib`
-
-`ln -s /usr/share/java/opencv.jar`
+`ln -s /usr/share/java/opencv.jar LAREX/Larex/src/main/webapp/WEB-INF/lib/opencv.jar`
 
 #### Compile
 run `mvn clean install` in the root dir. This dir contains the `pom.xml`.


### PR DESCRIPTION
All Unix commands should use the same $PWD. This should simplify the instructions for non technical users.

All commands where marked as such and the linking path for OpenCV was fixed.